### PR TITLE
Fixing rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '2.2.0'
+ruby '2.2.1'
 
 gem 'bundler'
 gem 'sinatra'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require 'bundler/setup'
+require 'rom/sql'
 require 'rom/sql/rake_task'
+
 require_relative 'db/db'
 
 namespace :db do


### PR DESCRIPTION
Ruby version bump.

+

Requiring 'rom/sql' to avoid errors in rake tasks
The error was:

```
NameError: uninitialized constant ROM
/PATH_TO_PROJECT/sinatra-rom/Rakefile:7:in `block (2 levels) in
<top (required)>'
Tasks: TOP => db:create_migration => db:load_setup
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gotar/sinatra-rom/1)

<!-- Reviewable:end -->
